### PR TITLE
SignUp, AdminSignIn, Admin 相關程式碼調整

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,18 +1,21 @@
 import { apiHelper } from "../utils/helpers";
 
+const getToken = () => localStorage.getItem("token");
+
 export default {
   getAllTweets() {
-    const token = localStorage.getItem("token");
-
     return apiHelper.get(`api/admin`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${getToken()}` },
     });
   },
   getAllUsers() {
-    const token = localStorage.getItem("token");
-
     return apiHelper.get(`api/admin/users`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${getToken()}` },
+    });
+  },
+  deleteTweet(id) {
+    return apiHelper.delete(`api/admin/tweets/${id}`, {
+      headers: { Authorization: `Bearer ${getToken()}` },
     });
   },
 };

--- a/src/api/authorization.js
+++ b/src/api/authorization.js
@@ -8,7 +8,7 @@ export default {
       password,
     });
   },
-  signUp({ data }) {
+  signUp(data) {
     return apiHelper.post("api/users", data);
   },
   logOut() {

--- a/src/api/authorization.js
+++ b/src/api/authorization.js
@@ -8,10 +8,8 @@ export default {
       password,
     });
   },
-  signUp({ formData }) {
-    return apiHelper.post("api/users", formData, {
-      headers: { "Content-Type": "multipart/form-data" },
-    });
+  signUp({ data }) {
+    return apiHelper.post("api/users", data);
   },
   logOut() {
     const keysToRemove = ["token", "user"];

--- a/src/components/AdminList.vue
+++ b/src/components/AdminList.vue
@@ -14,7 +14,7 @@
           {{ tweet.description }}
         </div>
       </div>
-      <div class="delete" @click="deleteTweet">
+      <div class="delete" @click="deleteTweet(tweet.id)">
         <svg
           width="24"
           height="24"
@@ -85,10 +85,8 @@
 
 <script>
 import { fromNowFilter } from "./../utils/mixins";
-import axios from "axios";
 import { Toast } from "./../utils/helpers";
-
-const getToken = () => localStorage.getItem("token");
+import admin from "./../api/admin";
 
 export default {
   name: "AdminList",
@@ -99,37 +97,50 @@ export default {
     };
   },
   methods: {
-    deleteTweet() {
-      console.log("delete");
-      // TODO 刪除資料
-    },
     // API
     async fetchApiData() {
       try {
-        const response = await axios.get(
-          "https://actwitter.herokuapp.com/api/admin",
-          {
-            headers: { Authorization: `Bearer ${getToken()}` },
-          }
-        );
-
-        console.log("admin");
-        console.log(response);
+        const response = await admin.getAllTweets();
 
         // 取得 API 請求後的資料
         const { data } = response;
 
         if (response.statusText !== "OK") {
-          throw new Error(data.message);
+          throw new Error();
         }
 
-        // TODO 載入資料
-        // this.tweets = data.allTweets;
+        // 載入 tweets 資料
+        this.tweets = [...data.allTweets];
+        // description 僅能看見前 50 字元
+        this.tweets.map((tweet) => {
+          if (tweet.description.length > 50) {
+            tweet.description = tweet.description.slice(0, 50) + "...";
+          }
+        });
       } catch (error) {
-        console.log("error", error);
+        console.log("error", error.response || error);
         Toast.fire({
           icon: "warning",
           title: "無法載入資料",
+        });
+      }
+    },
+    async deleteTweet(id) {
+      // 刪除資料
+      try {
+        const response = await admin.deleteTweet(id);
+
+        if (!response.data) {
+          throw new Error();
+        }
+
+        this.fetchApiData();
+      } catch (error) {
+        console.log(error.response || error);
+        Toast.fire({
+          icon: "warning",
+          title: "伺服器忙碌，請稍後再試",
+          position: "top",
         });
       }
     },

--- a/src/components/AdminUsers.vue
+++ b/src/components/AdminUsers.vue
@@ -154,7 +154,7 @@
 </style>
 
 <script>
-import axios from "axios";
+import admin from "./../api/admin"
 import { Toast } from "./../utils/helpers";
 
 export default {
@@ -166,9 +166,9 @@ export default {
   },
   methods: {
     // API
-    async fetchApiData() {
+    async fetchApiData() {      
       try {
-        const response = await axios.get("/api/admin");
+        const response = await admin.getAllUsers()
 
         console.log("admin");
         console.log(response);

--- a/src/views/AdminSignIn.vue
+++ b/src/views/AdminSignIn.vue
@@ -219,11 +219,11 @@ export default {
         );
 
         if (data.status !== "success" || data.user.role !== "admin") {
-          throw new Error('Invalid access');
+          throw new Error("Invalid access");
         }
 
         // 將 token 存放在 localStorage 內
-        localStorage.setItem("token", data.token);
+        localStorage.setItem("token", data.token.token);
 
         // 成功登入後轉址到首頁
         this.$router.push("/admin");

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -226,6 +226,8 @@ export default {
           email: this.email,
           password: this.password,
           checkPassword: this.checkPassword,
+          avatar: "",
+          cover: ""
         };
 
         if (

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -199,8 +199,8 @@
 </style>
 
 <script>
-import { apiHelper } from "./../utils/helpers";
 import { Toast } from "./../utils/helpers";
+import authorization from "./../api/authorization";
 
 export default {
   data() {
@@ -227,7 +227,7 @@ export default {
           password: this.password,
           checkPassword: this.checkPassword,
           avatar: "",
-          cover: ""
+          cover: "",
         };
 
         if (
@@ -253,7 +253,7 @@ export default {
           return;
         }
 
-        const response = await apiHelper.post("api/users", signUpData);
+        const response = await authorization.signUp(signUpData);
 
         // 取得 API 請求後的資料
         const { data } = response;


### PR DESCRIPTION
- 增加 SignUp 送到後端的資料項目，避免資料庫寫入 null 值
- 增加 Admin 頁面的功能: 刪除
- 調整 Admin 頁面的UI: 只看見每則推文前 50 字
- 調整 Admin 相關頁面的 api request functions
- 修正 SignUp post request 的 headers
- 修正 AdminSignIn localStorage 存放資料的 code

